### PR TITLE
chore: group Kubernetes dependencies in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,20 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Kubernetes dependencies (k8s.io/api, k8s.io/apimachinery, k8s.io/client-go, sigs.k8s.io/controller-runtime) must be updated in lockstep. Without grouping, Dependabot opens separate PRs for each, which fail CI due to version mismatches.

This adds a `kubernetes` dependency group to the gomod ecosystem so these packages are bumped together in a single PR. Also groups all github-actions updates into one PR for less noise.

Closes the now-superseded #35.