### PR TITLE
Fix stale docs and invalid kubebuilder marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Crane Autoscaler is a Kubernetes operator that coordinates HPA and VPA on the same workload. It prevents conflicts by enabling only one autoscaler at a time, switching between them based on resource utilization thresholds.
 
-Built with Kubebuilder v4, Go 1.23, and controller-runtime v0.19.
+Built with Kubebuilder v4, Go 1.25, and controller-runtime v0.19.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ It solves the problem that VPA and HPA cannot be used together on the same workl
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.25.0+
 - docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+- kubectl version v1.28+.
+- Access to a Kubernetes v1.28+ cluster.
 
 ### To Deploy on the cluster
 **Build and push your image to the location specified by `IMG`:**

--- a/api/v1alpha1/cranepodautoscaler_types.go
+++ b/api/v1alpha1/cranepodautoscaler_types.go
@@ -58,7 +58,6 @@ type CranePodAutoscalerStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:subresource:spec
 // +kubebuilder:subresource:status
 
 // CranePodAutoscaler is the Schema for the cranepodautoscalers API

--- a/internal/controller/cranepodautoscaler_controller.go
+++ b/internal/controller/cranepodautoscaler_controller.go
@@ -67,7 +67,7 @@ type CranePodAutoscalerReconciler struct {
 // move the current state of the cluster closer to the desired state.
 //
 // For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/reconcile
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.3/pkg/reconcile
 func (r *CranePodAutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 


### PR DESCRIPTION
The kubebuilder scaffold left behind several outdated values that were never updated to match the actual project requirements.

- Removed the invalid `+kubebuilder:subresource:spec` marker from `CranePodAutoscaler` type. Only `status` and `scale` are valid kubebuilder subresource markers; `spec` is not recognized and could cause code generation issues.
- Updated README prerequisites from the kubebuilder defaults (Go 1.22, K8s 1.11.3) to the actual project requirements (Go 1.25+, K8s/kubectl 1.28+), based on go.mod and CI test matrix.
- Updated the controller-runtime version in the Reconcile function comment from v0.18.4 to v0.19.3 to match go.mod.
- Updated Go version reference in CLAUDE.md from 1.23 to 1.25 to match go.mod.