### PR TITLE
fix: guard against nil VPA recommendation during reconciliation

### DIFF
--- a/internal/controller/cranepodautoscaler_controller.go
+++ b/internal/controller/cranepodautoscaler_controller.go
@@ -143,6 +143,11 @@ func (r *CranePodAutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		//               This should not happen.
 		activeAutoscaler = refHPA
 		passiveAutoscaler = refVPA
+	} else if vpa.Status.Recommendation == nil {
+		// Special case: VPA has no recommendation yet (e.g. just created).
+		//               We default to HPA as this is the safer option in terms of availability.
+		activeAutoscaler = refHPA
+		passiveAutoscaler = refVPA
 	} else {
 		// Usual case: VPA and HPA both already exist.
 		// 			   Now our action depends on the current scaling mode.

--- a/internal/controller/cranepodautoscaler_controller_test.go
+++ b/internal/controller/cranepodautoscaler_controller_test.go
@@ -466,6 +466,30 @@ var _ = Describe("CranePodAutoscaler Controller", func() {
 			Expect(decision.Reason).To(Equal("VPA"))
 		})
 
+		It("does not panic when VPA has no recommendation and defaults to HPA", func() {
+			const name = "test-nil-recommendation"
+			defer cleanup(ctx, name)
+
+			cpa := newCranePodAutoscaler(name)
+			Expect(k8sClient.Create(ctx, cpa)).To(Succeed())
+
+			// First reconcile: creates HPA+VPA, defaults to HPA active.
+			_, err := doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Set HPA at min replicas but leave VPA recommendation nil (no recommendation yet).
+			setHPAStatus(ctx, name, 2)
+
+			// Second reconcile: VPA has no recommendation. Must not panic and should stay on HPA.
+			_, err = doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn(name), cpa)).To(Succeed())
+			decision := meta.FindStatusCondition(cpa.Status.Conditions, "ScalingDecision")
+			Expect(decision).NotTo(BeNil())
+			Expect(decision.Reason).To(Equal("HPA"))
+		})
+
 		It("triggers HPA transition when memory exceeds threshold even if CPU is below", func() {
 			const name = "test-mem-threshold"
 			defer cleanup(ctx, name)


### PR DESCRIPTION
When a VPA has just been created and hasn't produced recommendations yet, `vpa.Status.Recommendation` is nil. The reconciler accesses `vpa.Status.Recommendation.ContainerRecommendations` without a nil guard, causing a nil pointer panic.

This adds a nil check before accessing `ContainerRecommendations`. When no recommendation is available the controller defaults to keeping HPA active, which is consistent with the existing safety-first approach used in other early-return branches. A regression test is included that reconciles with a nil VPA recommendation and verifies no panic occurs.