### PR TITLE
chore: remove commented-out dead code constant

### DIFF
--- a/internal/controller/cranepodautoscaler_controller.go
+++ b/internal/controller/cranepodautoscaler_controller.go
@@ -42,8 +42,6 @@ const (
 	refHPA = "HPA"
 	// typeAvailableCraneAutoscaler represents the status of the Deployment reconciliation
 	typeAvailableCraneAutoscaler = "Available"
-	// typeDegradedCraneAutoscaler represents the status used when the custom resource is deleted and the finalizer operations are yet to occur.
-	// typeDegradedCraneAutoscaler = "Degraded"
 	typeScalingDecisionCraneAutoscaler = "ScalingDecision"
 )
 

--- a/internal/controller/cranepodautoscaler_controller.go
+++ b/internal/controller/cranepodautoscaler_controller.go
@@ -41,7 +41,7 @@ const (
 	refVPA = "VPA"
 	refHPA = "HPA"
 	// typeAvailableCraneAutoscaler represents the status of the Deployment reconciliation
-	typeAvailableCraneAutoscaler = "Available"
+	typeAvailableCraneAutoscaler       = "Available"
 	typeScalingDecisionCraneAutoscaler = "ScalingDecision"
 )
 


### PR DESCRIPTION
Removes the commented-out `typeDegradedCraneAutoscaler` constant from the controller that was never used anywhere in the codebase.