### PR TITLE
fix: guard against nil VPA TargetRef and UpdatePolicy

### DIFF
--- a/api/v1alpha1/autoscaler_generators.go
+++ b/api/v1alpha1/autoscaler_generators.go
@@ -20,6 +20,9 @@ func (r *CranePodAutoscaler) GenerateEnabledVPA() *vpav1.VerticalPodAutoscaler {
 func (r *CranePodAutoscaler) GenerateDisabledVPA() *vpav1.VerticalPodAutoscaler {
 	vpaSpec := r.Spec.VPA.DeepCopy()
 	updateModeOff := vpav1.UpdateModeOff
+	if vpaSpec.UpdatePolicy == nil {
+		vpaSpec.UpdatePolicy = &vpav1.PodUpdatePolicy{}
+	}
 	vpaSpec.UpdatePolicy.UpdateMode = &updateModeOff
 	return &vpav1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -9,6 +9,9 @@ import (
 )
 
 func (r *CranePodAutoscaler) Validate() error {
+	if r.Spec.VPA.TargetRef == nil {
+		return fmt.Errorf("spec.VPA.targetRef must be set")
+	}
 	if !equalTargetRefs(r.Spec.VPA, r.Spec.HPA) {
 		return fmt.Errorf("spec.VPA.targetRef does not match spec.HPA.scaleTargetRef: %v", cmp.Diff(r.Spec.VPA.TargetRef, r.Spec.HPA.ScaleTargetRef))
 	}


### PR DESCRIPTION
`Validate()` dereferences `VPA.TargetRef` without a nil check, causing a panic instead of a validation error when `targetRef` is omitted. Added an explicit nil check that returns a descriptive error.

`GenerateDisabledVPA()` dereferences `UpdatePolicy` to set `UpdateModeOff` without checking for nil, panicking when no `updatePolicy` is specified in the VPA spec. Added a nil guard that initializes an empty `PodUpdatePolicy` before setting the mode.