### PR TITLE
fix: guard against division by zero in resource utilization calculation

### DIFF
--- a/internal/controller/cranepodautoscaler_controller.go
+++ b/internal/controller/cranepodautoscaler_controller.go
@@ -307,12 +307,18 @@ func getBiggestContainerResourceUtilization(vpaContainerResources []vpav1.Recomm
 	utilization := float32(0.0)
 	containerName := "NOCONTAINER"
 	for _, containerResource := range vpaContainerResources {
-		targetCpu := containerResource.Target.Cpu().MilliValue()
+		var cpuUtilization float32
 		upperBoundCpu := containerResource.UpperBound.Cpu().MilliValue()
-		cpuUtilization := float32(targetCpu) / float32(upperBoundCpu)
-		targetMem := containerResource.Target.Memory().Value()
+		if upperBoundCpu > 0 {
+			targetCpu := containerResource.Target.Cpu().MilliValue()
+			cpuUtilization = float32(targetCpu) / float32(upperBoundCpu)
+		}
+		var memUtilization float32
 		upperBoundMem := containerResource.UpperBound.Memory().Value()
-		memUtilization := float32(targetMem) / float32(upperBoundMem)
+		if upperBoundMem > 0 {
+			targetMem := containerResource.Target.Memory().Value()
+			memUtilization = float32(targetMem) / float32(upperBoundMem)
+		}
 
 		if cpuUtilization > utilization {
 			utilization = cpuUtilization

--- a/internal/controller/cranepodautoscaler_controller_test.go
+++ b/internal/controller/cranepodautoscaler_controller_test.go
@@ -111,6 +111,20 @@ func vpaContainerRecommendation(targetCPU, targetMem string) vpav1.RecommendedCo
 	}
 }
 
+func vpaContainerRecommendationWithUpperBound(targetCPU, targetMem, upperCPU, upperMem string) vpav1.RecommendedContainerResources {
+	return vpav1.RecommendedContainerResources{
+		ContainerName: "app",
+		Target: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(targetCPU),
+			corev1.ResourceMemory: resource.MustParse(targetMem),
+		},
+		UpperBound: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(upperCPU),
+			corev1.ResourceMemory: resource.MustParse(upperMem),
+		},
+	}
+}
+
 func cleanup(ctx context.Context, name string) {
 	nn := types.NamespacedName{Name: name, Namespace: testNS}
 
@@ -481,6 +495,70 @@ var _ = Describe("CranePodAutoscaler Controller", func() {
 			setHPAStatus(ctx, name, 2)
 
 			// Second reconcile: VPA has no recommendation. Must not panic and should stay on HPA.
+			_, err = doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn(name), cpa)).To(Succeed())
+			decision := meta.FindStatusCondition(cpa.Status.Conditions, "ScalingDecision")
+			Expect(decision).NotTo(BeNil())
+			Expect(decision.Reason).To(Equal("HPA"))
+		})
+
+		It("does not panic when VPA upper bound is zero and treats utilization as zero", func() {
+			const name = "test-zero-upperbound"
+			defer cleanup(ctx, name)
+
+			cpa := newCranePodAutoscaler(name)
+			Expect(k8sClient.Create(ctx, cpa)).To(Succeed())
+
+			// First reconcile: creates HPA+VPA, defaults to HPA active.
+			_, err := doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Set HPA at min replicas and VPA recommendation with zero upper bounds.
+			setHPAStatus(ctx, name, 2)
+			setVPARecommendation(ctx, name, []vpav1.RecommendedContainerResources{
+				vpaContainerRecommendationWithUpperBound("500m", "500Mi", "0", "0"),
+			})
+
+			// Reconcile must not panic and should transition to VPA
+			// since zero upper bound means zero utilization (below threshold).
+			_, err = doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn(name), cpa)).To(Succeed())
+			decision := meta.FindStatusCondition(cpa.Status.Conditions, "ScalingDecision")
+			Expect(decision).NotTo(BeNil())
+			Expect(decision.Reason).To(Equal("VPA"))
+		})
+
+		It("handles partial zero upper bound (only CPU zero) without panic", func() {
+			const name = "test-partial-zero-upperbound"
+			defer cleanup(ctx, name)
+
+			cpa := newCranePodAutoscaler(name)
+			Expect(k8sClient.Create(ctx, cpa)).To(Succeed())
+
+			_, err := doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Transition to VPA first.
+			setHPAStatus(ctx, name, 2)
+			setVPARecommendation(ctx, name, []vpav1.RecommendedContainerResources{
+				vpaContainerRecommendationWithUpperBound("500m", "500Mi", "1000m", "1000Mi"),
+			})
+			_, err = doReconcile(ctx, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, nn(name), cpa)).To(Succeed())
+			Expect(meta.FindStatusCondition(cpa.Status.Conditions, "ScalingDecision").Reason).To(Equal("VPA"))
+
+			// Now set CPU upper bound to zero but memory above threshold (90%).
+			// Memory utilization alone should trigger the switch to HPA.
+			setVPARecommendation(ctx, name, []vpav1.RecommendedContainerResources{
+				vpaContainerRecommendationWithUpperBound("500m", "900Mi", "0", "1000Mi"),
+			})
+
 			_, err = doReconcile(ctx, name)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
`getBiggestContainerResourceUtilization` divides `targetCpu` by `upperBoundCpu` and `targetMem` by `upperBoundMem` without checking for zero values. If a VPA recommendation has a zero `UpperBound` for CPU or memory, this causes a division by zero panic.

The fix adds zero-value guards before each division. When an upper bound is zero, utilization for that resource dimension is treated as zero (i.e. the container does not contribute to utilization for that dimension), which is the safest default since a zero upper bound means the VPA has no meaningful recommendation.

Two new test cases cover the scenario: one with both CPU and memory upper bounds at zero, and one with only CPU at zero while memory exceeds the threshold.